### PR TITLE
Refuse to process malformed SSH public key files.

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -854,7 +854,15 @@ ssh_listmissing() {
 
 	for slm_k in "$@"; do
 		# Fingerprint current user-specified key
-		slm_finger=$(ssh_f "$slm_k") || continue
+		if ! slm_finger=$(ssh_f "$slm_k"); then
+			warn "Unable to extract fingerprint from keyfile ${slm_k}.pub, skipping"
+			continue
+		fi
+		slm_wordcount="$(printf -- '%s\n' "$slm_finger" | wc -w)"
+		if [ "$slm_wordcount" -ne 1 ]; then
+			warn "Unable to extract exactly one key fingerprint from keyfile ${slm_k}.pub, got $slm_wordcount instead, skipping"
+			continue
+		fi
 
 		# Check if it needs to be added
 		case " $sshavail " in


### PR DESCRIPTION
If the user specifies a file that looks like an SSH public key file,
but it does not contain exactly one SSH public key (either it contains
none or the fingerprint is wrong or there is another key appended at
the end), keychain will misinterpret the "fingerprint" of the key file
and always try to load the corresponding private key.  This may lead
to repeated passphrase prompts and general user confusion.

A trivial way to reproduce this is to append a second line containing
the fingerprint of another SSH public key to a keyfile.

Debian bug:	https://bugs.debian.org/673019
Reported by:	Ryan Kavanagh <rak@debian.org>